### PR TITLE
chore: Update goreleaser.yml to version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 before:
   hooks:
     - go mod download


### PR DESCRIPTION
Fix the following error:

```
goreleaser --clean
  • starting release...
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
```