### PR TITLE
chore: Change changelog skip->disablen in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ checksum:
 snapshot:
   name_template: "{{ .Version }}-next"
 changelog:
-  skip: true
+  disable: true
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
Fix the following error:

```
goreleaser --clean
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 41: field skip not found in type config.Changelog
```